### PR TITLE
fix: realpath on mac

### DIFF
--- a/.common/common.fish
+++ b/.common/common.fish
@@ -6,6 +6,24 @@ if not functions -q fisher && status is-interactive
     isatty; and set_color normal
 end
 
+
+function _realpath_strip
+    set -l ostype (uname)
+    set -l cmd_realpath 'realpath'
+    if type -qf grealpath
+        set -l cmd_realpath 'grealpath'
+        set -l realpath_args '-s'
+    end
+
+    if test $ostype = "Linux"
+        set -l realpath_args '-s'
+    end
+
+    $cmd_realpath $realpath_args $argv
+end
+
+
+
 # add the given path into specified fish variables
 # return 0 on success, 1 on path not exist/invalid path, 2 on path already added, 3 others
 function fish_path_add
@@ -25,7 +43,7 @@ function fish_path_add
         isatty; and set_color normal
         return 1
     else
-        set -l pth (realpath -s $pth)
+        set -l pth (_realpath_strip $pth)
         if fish -c "contains -- $pth \$$fish_variable"
             isatty; and set_color yellow
             echo -e $pth already added in $fish_variable
@@ -53,7 +71,7 @@ function fish_path_rm
     end
 
     set -l fish_variable $argv[1]
-    set -l pth (realpath -s $argv[2] 2> /dev/null); or set -l pth $argv[2]
+    set -l pth (_realpath_strip $argv[2] 2> /dev/null); or set -l pth $argv[2]
 
     set -l index (fish -c "contains -i '$pth' \$$fish_variable; or echo 0")
     if test $index -gt 0
@@ -103,7 +121,7 @@ function addcompaths
                 echo -e \'$argv[1]\' not a existing path
                 set_color normal
             else
-                set -l pth (realpath -s $argv[1])
+                set -l pth (_realpath_strip $argv[1])
                 if contains -- $pth $fish_complete_path
                     set_color yellow
                     echo -e $pth already added

--- a/.common/common.zsh
+++ b/.common/common.zsh
@@ -32,6 +32,7 @@ alias ll="ls -al"
 alias cp="cp -v"
 alias mv="mv -v"
 alias rm="rm -v"
+alias tmux="env TERM=screen-256color tmux"
 
 export GPG_TTY=$(tty)
 

--- a/screen-256color.terminfo
+++ b/screen-256color.terminfo
@@ -5,9 +5,13 @@
 #
 #   tic screen-256color.terminfo
 #
+# compiled file goes to ~/.terminfo
+#
 # Usage:
 #
-#   export TERM=screen-256color
+#   env TERM=screen-256color tmux
+#
+# You may see screen-256color-it.terminfo as well
 #
 screen-256color|screen with 256 colors and italic,
         sitm=\E[3m, ritm=\E[23m,


### PR DESCRIPTION
BSD port of realpath do not supports '-s' flag
